### PR TITLE
Add extra assertions to prevent testSendData from failing due to indetermin…

### DIFF
--- a/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
+++ b/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
@@ -104,8 +104,10 @@ public class TestPrometheusRecordSink {
 
 
         final String content = getMetrics();
-        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n"));
-        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n"));
+        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\n"));
+        assertTrue(content.contains("field1{field3=\"World!\",} 6.0\n"));
+        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\n"));
+        assertTrue(content.contains("field2{field3=\"World!\",} 0.12345678901234568\n"));
 
         try {
             sink.onStopped();


### PR DESCRIPTION
…ate field ordering from HttpEntity.toString

The test `testSendData` compares the result of `HttpEntity.toString()` with a hardcoded string. However, the order of the fields returned from `toString()` was not deterministic. 

Since the order was not deterministic, tests could fail due to a different order. To fix flakiness, the two assertions that test for the hardcoded strings inside `HttpEntity` could be split into 4.

To replicate the non-deterministic behavior using [NonDex](https://github.com/TestingResearchIllinois/NonDex):

```
git checkout 2bd752d868a8f3e36113b078bb576cf054e945e8

mvn install -pl nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/ -am -DskipTests

mvn -pl nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/ test -Dtest=org.apache.nifi.reporting.prometheus.TestPrometheusRecordSink#testSendData

mvn -pl nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/ edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.nifi.reporting.prometheus.TestPrometheusRecordSink#testSendData
```

Replacing the assertions with the assertions proposed above leads to NonDex running tests successfully, without any indication of non-deterministic behavior.